### PR TITLE
change how to store the query

### DIFF
--- a/config.h
+++ b/config.h
@@ -83,7 +83,7 @@
 
 /* Maximum request, response size to keep per flow: */
 
-#define MAX_FLOW_DATA       8192
+#define MAX_FLOW_DATA       16384
 
 /* Maximum number of TCP options we will process (< 256): */
 

--- a/config.h
+++ b/config.h
@@ -45,7 +45,7 @@
 /* Default connection and host time limits (adjustable via -t): */
 
 #ifndef HOST_IDLE_LIMIT
-#  define CONN_MAX_AGE      30  /* seconds */
+#  define CONN_MAX_AGE      180  /* seconds */
 #  define HOST_IDLE_LIMIT   120 /* minutes */
 #endif /* !HOST_IDLE_LIMIT */
 
@@ -83,7 +83,7 @@
 
 /* Maximum request, response size to keep per flow: */
 
-#define MAX_FLOW_DATA       16384
+#define MAX_FLOW_DATA       32768
 
 /* Maximum number of TCP options we will process (< 256): */
 

--- a/config.h
+++ b/config.h
@@ -45,7 +45,7 @@
 /* Default connection and host time limits (adjustable via -t): */
 
 #ifndef HOST_IDLE_LIMIT
-#  define CONN_MAX_AGE      180  /* seconds */
+#  define CONN_MAX_AGE      300  /* seconds */
 #  define HOST_IDLE_LIMIT   120 /* minutes */
 #endif /* !HOST_IDLE_LIMIT */
 
@@ -83,7 +83,7 @@
 
 /* Maximum request, response size to keep per flow: */
 
-#define MAX_FLOW_DATA       32768
+#define MAX_FLOW_DATA       65536
 
 /* Maximum number of TCP options we will process (< 256): */
 

--- a/process.c
+++ b/process.c
@@ -1305,7 +1305,8 @@ static void flow_dispatch(struct packet_data* pk) {
       }
 
       f = create_flow_from_syn(pk);
-	SAYF("start if\n");
+      SAYF("start if\n");
+      
       if(strlen(f_syn[f->bucket]->data) > 0){
 	SAYF("if count\n");
 	nsd = ck_alloc(sizeof(struct syn_data));

--- a/process.c
+++ b/process.c
@@ -1256,7 +1256,7 @@ static void flow_dispatch(struct packet_data* pk) {
   char json_data[MAX_FLOW_DATA]={'\0'};
   u32 flow_number = 0;
   static int cnt = 0;
-  //u32 read_amt = 0;
+  u32 read_amt = 0;
 
   SAYF("%d\n",++cnt);
 
@@ -1448,12 +1448,12 @@ static void flow_dispatch(struct packet_data* pk) {
 
         if (f->req_len < MAX_FLOW_DATA && pk->pay_len) {
 
-          u32 read_amt = MIN(pk->pay_len, MAX_FLOW_DATA - f->req_len);
+          read_amt = MIN(pk->pay_len, MAX_FLOW_DATA - f->req_len);
 
           f->request = ck_realloc_kb(f->request, f->req_len + read_amt + 1);
           memcpy(f->request + f->req_len, pk->payload, read_amt);
-          f->req_len += read_amt;
-	  SAYF("%s\n",f->request);
+	  f->req_len += read_amt;
+	  SAYF("%s\n",f->request+f->req_len-read_amt);
 
         }
 
@@ -1462,7 +1462,7 @@ static void flow_dispatch(struct packet_data* pk) {
 
 	if(pk->payload != NULL){
 	  SAYF("req_length: %u\n",f->req_len);
-	  query_to_json((char *)f->request,json_data);
+	  query_to_json((char *)f->request+f->req_len-read_amt,json_data);
 	  if(strlen(f_syn[f->bucket].data) != 0 && strlen(fp_sig[f->bucket]) == 0){
 	    sprintf(fp_sig[f->bucket],"{%s\"reqests\":[{%s",f_syn[f->bucket].data,json_data);
 	    strcat(fp_sig[f->bucket],"}");

--- a/process.c
+++ b/process.c
@@ -1598,7 +1598,7 @@ static void flow_dispatch(struct packet_data* pk) {
 	  
 	  if(strlen(f_syn[f->bucket]->data) != 0 && strlen(fp_sig[f->bucket]->fp_sig) == 0){
 	    //SAYF("start sprintf\n");
-	    sprintf(fp_sig[f->bucket]->fp_sig,"{%s\"reqests\":[{%s",f_syn[f->bucket]->data,json_data);
+	    sprintf(fp_sig[f->bucket]->fp_sig,"{%s\"requests\":[{%s",f_syn[f->bucket]->data,json_data);
 	    strcat(fp_sig[f->bucket]->fp_sig,"}");
 	    //SAYF("written syn at %u\n",f->bucket);
 	    //memset(syn_data,'\0',sizeof());

--- a/process.c
+++ b/process.c
@@ -62,6 +62,7 @@ static void nuke_flows(u8 silent);
 static void expire_cache(void);
 
 void change_char(char* key);		/* Change charctor size and escape charctor(ex.'A' -> 'a', '-' -> '_') */
+void delete_quotation(char *value);	/* Delete double quotation marker (ex. "aabbcc" -> aabbcc ) */
 
 /* Get unix time in milliseconds. */
 
@@ -1163,6 +1164,7 @@ void query_to_json(char* src_data, char* res_data){
 		change_char(h[i].name);
                 strcat(res_data,h[i].name);
                 strcat(res_data,"\":\"");
+		delete_quotation(h[i].value);
                 strcat(res_data,h[i].value);
                 strcat(res_data,"\"");
 		if(i+1 == count) break;
@@ -1202,7 +1204,7 @@ void split_data(char* src, char* pointer, int cnt, struct http_header *query){
 void change_char(char* key){
 	
 	char* tmp;
-
+	
 	tmp = key;
 	while(*tmp != '\0'){
 		if(*tmp >= 'A' && *tmp <= 'Z'){
@@ -1213,6 +1215,36 @@ void change_char(char* key){
 		}
 		tmp++;
 	}
+
+	return;
+}
+
+/* delete quotation marker */
+
+void delete_quotation(char *value){
+
+	char* ptn;
+	char *tmp = (char *)malloc(strlen(value)+1);
+
+	ptn = value;
+	while(*ptn != '\0'){
+		if(*ptn == '\"'){
+			*ptn = '\0';
+			if(*(ptn+1) == '\0'){
+				break;
+			}
+			else{
+				ptn++;
+				strcpy(tmp,ptn);
+				strcat(value,tmp);
+			}
+		}
+		else{
+			ptn++;
+		}
+	}
+
+	free(tmp);
 
 	return;
 }

--- a/process.h
+++ b/process.h
@@ -184,6 +184,7 @@ struct packet_flow {
   u16 syn_mss;                          /* MSS on SYN packet                  */
 
   u32 created;                          /* Flow creation date (unix time)     */
+  u32 updated;                          /* Flow updated  date (unix time)     */
 
   /* Application-level fingerprinting: */
 
@@ -200,7 +201,7 @@ struct packet_flow {
 
 struct syn_data{					/* struct of SYN signature every packet flows */
 	struct syn_data *prev, *next;			/* If bucket is same, store the both data */	
-	char data[512];					/* SYN signature */
+	char data[300];					/* SYN signature */
 	u32  bucket;					/* unique flow ID */
 
 };

--- a/process.h
+++ b/process.h
@@ -198,11 +198,16 @@ struct packet_flow {
 
 };
 
-struct syn_data{			/* struct of SYN signature every packet flows */
-	
-	char data[512];			/* SYN signature 	*/
-	u32  bucket;			/* unique flow ID 	*/
+struct syn_data{					/* struct of SYN signature every packet flows */
+	struct syn_data *prev, *next;			/* If bucket is same, store the both data */	
+	char data[512];					/* SYN signature */
+	u32  bucket;					/* unique flow ID */
 
+};
+
+struct p0f_query{				/* Like syn_data */
+	struct p0f_query *prev, *next;
+	char fp_sig[MAX_FLOW_DATA];
 };
 
 struct http_header{			/* struct of HTTP request header      */

--- a/process.h
+++ b/process.h
@@ -194,10 +194,18 @@ struct packet_flow {
   u8  http_gotresp1;                    /* Got initial line of a response?    */
 
   struct http_sig http_tmp;             /* Temporary signature                */
+  /*struct syn_sig  syn_tmp;*/		/* Temporary SYN signature            */
 
 };
 
-struct http_header{			/* struct of HTTP request header */
+struct syn_data{			/* struct of SYN signature every packet flows */
+	
+	char data[512];			/* SYN signature 	*/
+	u32  bucket;			/* unique flow ID 	*/
+
+};
+
+struct http_header{			/* struct of HTTP request header      */
         char* name;
         char* value;
 };


### PR DESCRIPTION
- 送信元のIP,PORT番号と宛先のIP,PORT番号を用いて[ハッシュ値を生成](https://github.com/KenFujita/p0f/blob/master/process.c#L752)していたので、ハッシュ値を用いて二次元配列でクエリを格納するように変更した。
- そうすることで、フロー毎のSYNパケット情報とHTTPリクエストを関連付けできると判断した。
- to_srvという変数で「cli -> srv」の通信なのか「srv -> cli」の通信かを判断しているらしく、cli -> srvのときFINが送られた時にSYN情報とHTTPリクエストを紐づけようとした。
    - しかしこのto_srvの値は関係なさそうで、正しい情報ではなかったので上記のような実装に踏み切った。